### PR TITLE
build(cmake): add CMake project with Python3 dev detection and example target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(mt5bridge_cpp LANGUAGES CXX)
+
+option(BUILD_EXAMPLES "Build example programs" ON)
+
+find_package(Python3 REQUIRED COMPONENTS Development)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(JANSSON REQUIRED jansson)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+add_library(mt5_bridge SHARED src/mt5_bridge.cpp)
+target_include_directories(mt5_bridge
+    PUBLIC
+        ${PROJECT_SOURCE_DIR}/include
+        ${JANSSON_INCLUDE_DIRS}
+)
+target_link_libraries(mt5_bridge
+    PUBLIC
+        Python3::Python
+        ${JANSSON_LIBRARIES}
+)
+
+if(BUILD_EXAMPLES)
+    add_executable(usage_example examples/usage_example.cpp)
+    target_link_libraries(usage_example PRIVATE ${JANSSON_LIBRARIES})
+    set_target_properties(usage_example PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+endif()
+


### PR DESCRIPTION
## Summary
- add root CMake build system with Python3 dev detection
- build mt5_bridge library and optional usage example

## Testing
- `cmake -S . -B build`

------
https://chatgpt.com/codex/tasks/task_e_68bb6a894e94832c95c694c276ce7826