### PR TITLE
docs(readme): add quickstart, build and runtime preparation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
 # mt5bridge_cpp
-C++17 bridge embedding CPython to call the MetaTrader5 Python API from native apps (quotes, bars, orders). Ships with embeddable Python. Windows x64
+
+C++17 bridge embedding CPython to call the MetaTrader5 Python API from native apps (quotes, bars, orders). Ships with an embeddable Python runtime. Windows x64 only.
+
+## Quickstart
+
+1. Clone the repository.
+2. Build the bridge using MSVC or MinGW.
+3. Prepare the runtime environment.
+4. Run an example to confirm the setup.
+
+## Build
+
+### MSVC
+
+```powershell
+# From a Developer PowerShell
+cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+cmake --build build --config Release
+```
+
+### MinGW
+
+```bash
+cmake -S . -B build -G "MinGW Makefiles"
+cmake --build build
+```
+
+## Runtime setup
+
+1. Install MetaTrader 5 and log into an account.
+2. Ensure the `python` runtime folder from this repository accompanies your application or set `PYTHONHOME` to that path.
+3. Create `bridge.ini` with `terminal_path` pointing at the MT5 terminal directory.
+
+## Example usage
+
+```cpp
+#include <mt5bridge/mt5bridge.hpp>
+
+int main() {
+    mt5::Bridge bridge;
+    bridge.initialize();
+    auto quotes = bridge.get_quotes("EURUSD");
+    // use quotes...
+}
+```
+
+See the `examples` directory for more.
+
+## Notes
+
+- Only 64‑bit Windows builds are supported.
+- Python 3.11+ is required.
+- Issues and pull requests are welcome.
+


### PR DESCRIPTION
## Summary
- document quickstart steps and builds for MSVC and MinGW
- outline runtime setup for MetaTrader5 bridge
- include example usage and project notes

## Testing
- `cmake -S . -B build` *(fails: jansson not found)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb6dc6bf44832c8f21f991dac46cc4