### PR TITLE
chore(scripts): add MSVC build script and integrate runtime preparation

### DIFF
--- a/scripts/build_msvc.bat
+++ b/scripts/build_msvc.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal
+
+REM URL to the embeddable Python runtime
+set PYTHON_URL=https://www.python.org/ftp/python/3.11.5/python-3.11.5-embed-amd64.zip
+
+REM Configure and build with MSVC
+cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+if %errorlevel% neq 0 goto error
+
+cmake --build build --config Release
+if %errorlevel% neq 0 goto error
+
+REM Prepare the embeddable Python runtime
+python scripts\prepare_py_runtime.py --python-url %PYTHON_URL% --output python
+if %errorlevel% neq 0 goto error
+
+echo Build and runtime preparation complete.
+goto end
+
+:error
+echo Build or runtime preparation failed.
+exit /b 1
+
+:end
+exit /b 0


### PR DESCRIPTION
## Summary
- add build_msvc.bat to configure and build with Visual Studio 2022
- integrate Python runtime preparation into the build script

## Testing
- `cmake -S . -B build` *(fails: The following required packages were not found: jansson)*
- `python scripts/prepare_py_runtime.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68bb70171f00832cada8d7f0c4057c51