### PR TITLE
test(smoke): add minimal smoke test runnable without MT5 terminal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,5 +29,9 @@ if(BUILD_EXAMPLES)
     add_executable(usage_example examples/usage_example.cpp)
     target_link_libraries(usage_example PRIVATE ${JANSSON_LIBRARIES})
     set_target_properties(usage_example PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+
+    add_executable(smoke_no_mt5 examples/smoke_no_mt5.cpp)
+    target_link_libraries(smoke_no_mt5 PRIVATE ${JANSSON_LIBRARIES})
+    set_target_properties(smoke_no_mt5 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 endif()
 

--- a/examples/smoke_no_mt5.cpp
+++ b/examples/smoke_no_mt5.cpp
@@ -1,0 +1,71 @@
+#include <windows.h>
+#include <iostream>
+#include <jansson.h>
+
+using mt5bridge_initialize_t = int (*)(const wchar_t *);
+using mt5bridge_shutdown_t = void (*)();
+using mt5bridge_eval_t = json_t *(*)(json_t *);
+using mt5bridge_last_error_t = const char *(*)();
+
+int main() {
+    // Load the bridge DLL dynamically.
+    HMODULE dll = LoadLibraryW(L"mt5_bridge.dll");
+    if (!dll) {
+        std::cerr << "Failed to load mt5_bridge.dll" << std::endl;
+        return 1;
+    }
+
+    // Resolve required API functions.
+    auto mt5bridge_initialize =
+        reinterpret_cast<mt5bridge_initialize_t>(
+            GetProcAddress(dll, "mt5bridge_initialize"));
+    auto mt5bridge_shutdown =
+        reinterpret_cast<mt5bridge_shutdown_t>(
+            GetProcAddress(dll, "mt5bridge_shutdown"));
+    auto mt5bridge_eval = reinterpret_cast<mt5bridge_eval_t>(
+        GetProcAddress(dll, "mt5bridge_eval"));
+    auto mt5bridge_last_error =
+        reinterpret_cast<mt5bridge_last_error_t>(
+            GetProcAddress(dll, "mt5bridge_last_error"));
+
+    if (!mt5bridge_initialize || !mt5bridge_shutdown || !mt5bridge_eval ||
+        !mt5bridge_last_error) {
+        std::cerr << "Failed to resolve mt5_bridge API" << std::endl;
+        FreeLibrary(dll);
+        return 1;
+    }
+
+    // Initialize the bridge; this succeeds even without a running terminal.
+    if (mt5bridge_initialize(nullptr) != 0) {
+        std::cerr << "Initialization failed: " << mt5bridge_last_error()
+                  << std::endl;
+        FreeLibrary(dll);
+        return 1;
+    }
+
+    // Issue a minimal request. Without a terminal the response will be
+    // JSON null, which is still useful for exercising the pipeline.
+    json_t *req = json_pack("{s:s,s:s,s:i}",
+                            "method", "get_m1_bars",
+                            "symbol", "EURUSD",
+                            "count", 1);
+    json_t *resp = mt5bridge_eval(req);
+    json_decref(req);
+
+    if (!resp) {
+        std::cerr << "mt5bridge_eval failed: " << mt5bridge_last_error()
+                  << std::endl;
+        mt5bridge_shutdown();
+        FreeLibrary(dll);
+        return 1;
+    }
+
+    json_dumpf(resp, stdout, JSON_INDENT(2));
+    std::cout << std::endl;
+    json_decref(resp);
+
+    mt5bridge_shutdown();
+    FreeLibrary(dll);
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add `smoke_no_mt5` example that loads bridge DLL, issues minimal request, and shuts down
- expose new smoke example through CMake when building examples

## Testing
- `cmake -S . -B build`
- `cmake --build build --target smoke_no_mt5` *(fails: examples/smoke_no_mt5.cpp:1:10: fatal error: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb71185874832cb53cbd6a3c52e1d1